### PR TITLE
(chore) removes deprecated @types/testing-library__jest-dom

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: "18.x"
 
       - name: Cache dependencies
         id: cache

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@types/lodash-es": "^4.17.12",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
-    "@types/testing-library__jest-dom": "^6.0.0",
     "@types/webpack-env": "^1.18.4",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@typescript-eslint/parser": "^6.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3366,7 +3366,6 @@ __metadata:
     "@types/lodash-es": "npm:^4.17.12"
     "@types/react": "npm:^18.2.48"
     "@types/react-dom": "npm:^18.2.18"
-    "@types/testing-library__jest-dom": "npm:^6.0.0"
     "@types/webpack-env": "npm:^1.18.4"
     "@typescript-eslint/eslint-plugin": "npm:^6.19.1"
     "@typescript-eslint/parser": "npm:^6.19.1"
@@ -5023,7 +5022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:*, @testing-library/jest-dom@npm:^6.3.0":
+"@testing-library/jest-dom@npm:^6.3.0":
   version: 6.3.0
   resolution: "@testing-library/jest-dom@npm:6.3.0"
   dependencies:
@@ -5628,15 +5627,6 @@ __metadata:
   version: 1.2.2
   resolution: "@types/symlink-or-copy@npm:1.2.2"
   checksum: fb8fc2a356d1d7ab222bbea772ca6bf1b4a90b1f14ea46c1522643d3afd018f3b938ead7ba04af88175432a07497c02904bf428008505acf8a4745f1bc6e3892
-  languageName: node
-  linkType: hard
-
-"@types/testing-library__jest-dom@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@types/testing-library__jest-dom@npm:6.0.0"
-  dependencies:
-    "@testing-library/jest-dom": "npm:*"
-  checksum: 1b4db1aa3c4225524203b4d1c3b36c7129e9d1e0547e46d2e5283c3ece226a3c16f5f20387cc71b33ab0eecd99d0cf91111bb327e8adb240388d99fb94af7a4d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).


## Summary

Removes deprecated `@types/testing-library__jest-dom` which was causing failure with `yarn verify`

<img width="1236" alt="Screenshot 2024-01-31 at 11 09 25" src="https://github.com/openmrs/openmrs-esm-billing-app/assets/15266028/14c00ee9-5f24-4c85-9580-cc28ed068e82">

