### PR TITLE
(Chore) Refactor Service metrics extension slot

### DIFF
--- a/src/billable-services/dashboard/dashboard.component.tsx
+++ b/src/billable-services/dashboard/dashboard.component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import BillableServices from '../billable-services.component';
 import ServiceMetrics from './service-metrics.component';
 import styles from './dashboard.scss';
+import { ExtensionSlot } from '@openmrs/esm-framework';
 
 export default function BillableServicesDashboard() {
   return (
@@ -10,6 +11,7 @@ export default function BillableServicesDashboard() {
       <main className={styles.servicesTableContainer}>
         <BillableServices />
       </main>
+      <ExtensionSlot name="billing-home-tiles-slot" />
     </main>
   );
 }

--- a/src/billable-services/dashboard/dashboard.component.tsx
+++ b/src/billable-services/dashboard/dashboard.component.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import BillableServices from '../billable-services.component';
-import ServiceMetrics from './service-metrics.component';
 import styles from './dashboard.scss';
 import { ExtensionSlot } from '@openmrs/esm-framework';
 
 export default function BillableServicesDashboard() {
   return (
     <main className={styles.container}>
-      <ServiceMetrics />
+      <ExtensionSlot name="billing-home-tiles-slot" />
       <main className={styles.servicesTableContainer}>
         <BillableServices />
       </main>
-      <ExtensionSlot name="billing-home-tiles-slot" />
     </main>
   );
 }

--- a/src/billable-services/dashboard/service-metrics.component.tsx
+++ b/src/billable-services/dashboard/service-metrics.component.tsx
@@ -7,7 +7,7 @@ import Card from '../../metrics-cards/card.component';
 import styles from '../../metrics-cards/metrics-cards.scss';
 import { ExtensionSlot } from '@openmrs/esm-framework';
 
-function ServiceMetrics() {
+export default function ServiceMetrics() {
   const { t } = useTranslation();
   const { isLoading, error } = useBillableServices();
 
@@ -39,5 +39,3 @@ function ServiceMetrics() {
     </section>
   );
 }
-
-export default React.memo(ServiceMetrics);

--- a/src/billable-services/dashboard/service-metrics.component.tsx
+++ b/src/billable-services/dashboard/service-metrics.component.tsx
@@ -7,7 +7,7 @@ import Card from '../../metrics-cards/card.component';
 import styles from '../../metrics-cards/metrics-cards.scss';
 import { ExtensionSlot } from '@openmrs/esm-framework';
 
-export default function ServiceMetrics() {
+function ServiceMetrics() {
   const { t } = useTranslation();
   const { isLoading, error } = useBillableServices();
 
@@ -40,3 +40,5 @@ export default function ServiceMetrics() {
     </section>
   );
 }
+
+export default React.memo(ServiceMetrics);

--- a/src/billable-services/dashboard/service-metrics.component.tsx
+++ b/src/billable-services/dashboard/service-metrics.component.tsx
@@ -36,7 +36,6 @@ function ServiceMetrics() {
       {cards.map((card) => (
         <Card key={card.title} title={card.title} count={card.count} />
       ))}
-      <ExtensionSlot name="billing-home-tiles-slot" />
     </section>
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,8 +41,6 @@ export const billingSummaryDashboardLink = getSyncLifecycle(
   options,
 );
 
-// export const billingServicesTiles = getSyncLifecycle(ServiceMetrics, options);
-
 export const billableServicesCardLink = getSyncLifecycle(BillableServicesCardLink, options);
 export const billableServicesHome = getSyncLifecycle(BillableServiceHome, options);
 export const billingCheckInForm = getSyncLifecycle(BillingCheckInForm, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,14 +41,12 @@ export const billingSummaryDashboardLink = getSyncLifecycle(
   options,
 );
 
-export const billingServicesTiles = getSyncLifecycle(ServiceMetrics, {
-  featureName: 'billing-home-tiles',
-  moduleName,
-});
+// export const billingServicesTiles = getSyncLifecycle(ServiceMetrics, options);
 
 export const billableServicesCardLink = getSyncLifecycle(BillableServicesCardLink, options);
 export const billableServicesHome = getSyncLifecycle(BillableServiceHome, options);
 export const billingCheckInForm = getSyncLifecycle(BillingCheckInForm, options);
+export const serviceMetrics = getSyncLifecycle(ServiceMetrics, options);
 export const billingForm = getSyncLifecycle(BillingForm, options);
 export const billingPatientSummary = getSyncLifecycle(BillHistory, options);
 export const requirePaymentModal = getSyncLifecycle(RequirePaymentModal, options);

--- a/src/routes.json
+++ b/src/routes.json
@@ -73,7 +73,7 @@
     {
       "name": "billing-home-tiles-ext",
       "slot": "billing-home-tiles-slot",
-      "component": "ServiceMetrics"
+      "component": "serviceMetrics"
     }
   ]
 }

--- a/src/routes.json
+++ b/src/routes.json
@@ -73,7 +73,7 @@
     {
       "name": "billing-home-tiles-ext",
       "slot": "billing-home-tiles-slot",
-      "component": "billingServicesTiles"
+      "component": "ServiceMetrics"
     }
   ]
 }


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
There was an issue loading the billing service metrics that would cause so many queries to the endpoint `/billableService?`  until it crashes, breaking the metrics dashboard as well. This PR resolves that by refactoring the way the extension slot for the service metrics component is injected

## Screenshots

https://github.com/openmrs/openmrs-esm-billing-app/assets/43242517/ccf6ef64-40c7-4ba3-9f45-e93dd96df593




## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
