### PR TITLE
(fix) Save and Close button should be disabled when quantity item is less than 1

### DIFF
--- a/src/billing-form/billing-form.component.tsx
+++ b/src/billing-form/billing-form.component.tsx
@@ -330,7 +330,7 @@ const BillingForm: React.FC<BillingFormProps> = ({ patientUuid, closeWorkspace }
             className={styles.button}
             kind="primary"
             onClick={postBillItems}
-            disabled={isSubmitting && saveDisabled}
+            disabled={isSubmitting || saveDisabled}
             type="submit">
             {isSubmitting ? (
               <InlineLoading description={t('saving', 'Saving') + '...'} />


### PR DESCRIPTION

## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
This fixes an issue where the save button is not disabled when a user adds a quantity item less than 1. Which would add zero item thus a zero bill

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-billing-app/assets/43242517/52d44931-ce1a-4ed2-97e0-91886e79e771)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
