### PR TITLE
Fix truncated items on Line items table

### DIFF
--- a/src/bill-history/bill-history.scss
+++ b/src/bill-history/bill-history.scss
@@ -149,13 +149,15 @@
   table-layout: fixed; // This helps with uniform column sizing
   border-collapse: collapse;
 
-  th, td {
-    text-align: left;
-    padding: layout.$spacing-03; // Use a variable or a fixed value
-    border-bottom: 1px solid $ui-03;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  td:has(:global(.billingTable)) {
+    td{
+      padding: 0.375rem 2rem 0.4375rem !important;
+      white-space:normal;
+      text-overflow: unset;
+    }
+  }
+  :global(tr.cds--parent-row.cds--expandable-row + tr[data-child-row]) td {
+    padding-left: 1rem;
   }
 }
 

--- a/src/invoice/invoice-table.component.tsx
+++ b/src/invoice/invoice-table.component.tsx
@@ -159,7 +159,10 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({ bill, isSelectable = true, 
               placeholder={t('searchThisTable', 'Search this table')}
               size={responsiveSize}
             />
-            <Table {...getTableProps()} aria-label="Invoice line items" className={styles.table}>
+            <Table
+              {...getTableProps()}
+              aria-label="Invoice line items"
+              className={`${styles.invoiceTable} billingTable`}>
               <TableHead>
                 <TableRow>
                   {rows.length > 1 && isSelectable ? <TableHeader /> : null}

--- a/src/invoice/invoice-table.scss
+++ b/src/invoice/invoice-table.scss
@@ -41,7 +41,7 @@
   }
 }
 
-.table {
+.invoiceTable {
   width: 100%;
   table-layout: fixed;
   border-collapse: collapse;


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
The line items on the billing history were truncated with ellipsis making it hard to read text, this PR fixes this. 

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-billing-app/assets/43242517/92fb87fa-9564-47dc-a734-07ac176ea357)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
