### PR TITLE
(Enhancement) Change Price to read-Only in bill edit modal

### DIFF
--- a/src/bill-item-actions/edit-bill-item.component.tsx
+++ b/src/bill-item-actions/edit-bill-item.component.tsx
@@ -156,15 +156,14 @@ const ChangeStatus: React.FC<BillLineItemProps> = ({ bill, item, closeModal }) =
               <Controller
                 name="price"
                 control={control}
-                render={({ field: { onChange, onBlur, value } }) => (
+                render={({ field: { value } }) => (
                   <NumberInput
                     id="priceInput"
-                    label={t('price', 'Price')}
+                    label={t('price', 'Unit Price')}
                     value={value}
-                    onChange={onChange}
+                    readOnly={true}
                     className={styles.controlField}
-                    invalid={errors.price?.message}
-                    invalidText={errors.price?.message}
+                    helperText="This is the unit Price for this item."
                   />
                 )}
               />

--- a/translations/en.json
+++ b/translations/en.json
@@ -86,7 +86,7 @@
   "policyNumber": "Policy number",
   "postWaiver": "Post waiver",
   "previousPage": "Previous page",
-  "price": "Price",
+  "price": "Unit Price",
   "priceIsRequired": "Price is required",
   "prices": "Prices",
   "printBill": "Print bill",


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
The approach used was to make the unit price a read only and have quantity only changeable

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-billing-app/assets/43242517/db7b36af-0300-4c67-9c69-e1053ab98e88)

## Related Issue
[Issue](https://openmrs.atlassian.net/browse/O3-3262)

## Other
<!-- Anything not covered above -->
<!-- *None* -->
