### PR TITLE
(feat) O3-4082: Make currency in billing form configurable

### DIFF
--- a/src/billing-form/billing-form.component.tsx
+++ b/src/billing-form/billing-form.component.tsx
@@ -268,7 +268,7 @@ const BillingForm: React.FC<BillingFormProps> = ({ patientUuid, closeWorkspace }
                     id={row.uuid}
                     onClick={(e) => addItemToBill(e, row.uuid, row.Item, row.category, row.Price)}
                     style={{ background: 'inherit', color: 'black' }}>
-                    {row.Item} Qnty.{row.Qnty} Ksh.{row.Price}
+                    {row.Item} Qnty.{row.Qnty} {defaultCurrency}.{row.Price}
                   </Button>
                 </li>
               ))}


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Sets the currency in the billing form to use the `defaultCurrency` instead of hard-coded currency units

## Screenshots
![image](https://github.com/user-attachments/assets/da30e255-9ff2-4571-ad46-dab13811698e)
![configure-form-currency](https://github.com/user-attachments/assets/c10616f1-7b68-4fa0-8dc6-f412a303e9f8)


## Related Issue
[O3-4082](https://openmrs.atlassian.net/browse/O3-4082)

## Other
<!-- Anything not covered above -->
<!-- *None* -->


[O3-4082]: https://openmrs.atlassian.net/browse/O3-4082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ