### PR TITLE
(Refactor)Patient Categories should be configurable

### DIFF
--- a/src/billing-form/visit-attributes/visit-attributes-form.component.tsx
+++ b/src/billing-form/visit-attributes/visit-attributes-form.component.tsx
@@ -21,11 +21,6 @@ type VisitAttributesFormValue = {
   patientCategory: string;
 };
 
-type PatientCategoryOption = {
-  text: string;
-  uuid: string;
-};
-
 const visitAttributesFormSchema = z.object({
   paymentDetails: z.string(),
   paymentMethods: z.string(),
@@ -36,14 +31,13 @@ const visitAttributesFormSchema = z.object({
 
 const VisitAttributesForm: React.FC<VisitAttributesFormProps> = ({ setAttributes, setPaymentMethod }) => {
   const { t } = useTranslation();
-  const config = useConfig();
+  const { patientCatergory, catergoryConcepts, nonPayingPatientCategories } = useConfig();
   const { control, getValues, watch } = useForm<VisitAttributesFormValue>({
     mode: 'all',
     defaultValues: {},
     resolver: zodResolver(visitAttributesFormSchema),
   });
 
-  const { patientCatergory, catergoryConcepts, patientCategories } = config;
   const [paymentDetails, paymentMethods, insuranceSchema, policyNumber, patientCategory] = watch([
     'paymentDetails',
     'paymentMethods',
@@ -53,12 +47,12 @@ const VisitAttributesForm: React.FC<VisitAttributesFormProps> = ({ setAttributes
   ]);
 
   const { paymentModes, isLoading: isLoadingPaymentModes } = usePaymentMethods();
-  const patientCategoryOptions: PatientCategoryOption[] = React.useMemo(() => {
-    return (patientCategories?.categories || []).map((category) => ({
-      text: category.text,
-      uuid: category.uuid,
+  const patientCategoryOptions = React.useMemo(() => {
+    return Object.entries(nonPayingPatientCategories ?? {}).map(([key, uuid]) => ({
+      text: key,
+      uuid,
     }));
-  }, [patientCategories]);
+  }, [nonPayingPatientCategories]);
 
   React.useEffect(() => {
     setAttributes(createVisitAttributesPayload());

--- a/src/billing-form/visit-attributes/visit-attributes-form.component.tsx
+++ b/src/billing-form/visit-attributes/visit-attributes-form.component.tsx
@@ -21,6 +21,11 @@ type VisitAttributesFormValue = {
   patientCategory: string;
 };
 
+type PatientCategoryOption = {
+  text: string;
+  uuid: string;
+};
+
 const visitAttributesFormSchema = z.object({
   paymentDetails: z.string(),
   paymentMethods: z.string(),
@@ -31,12 +36,14 @@ const visitAttributesFormSchema = z.object({
 
 const VisitAttributesForm: React.FC<VisitAttributesFormProps> = ({ setAttributes, setPaymentMethod }) => {
   const { t } = useTranslation();
+  const config = useConfig();
   const { control, getValues, watch } = useForm<VisitAttributesFormValue>({
     mode: 'all',
     defaultValues: {},
     resolver: zodResolver(visitAttributesFormSchema),
   });
-  const { patientCatergory, catergoryConcepts } = useConfig();
+
+  const { patientCatergory, catergoryConcepts, patientCategories } = config;
   const [paymentDetails, paymentMethods, insuranceSchema, policyNumber, patientCategory] = watch([
     'paymentDetails',
     'paymentMethods',
@@ -46,13 +53,20 @@ const VisitAttributesForm: React.FC<VisitAttributesFormProps> = ({ setAttributes
   ]);
 
   const { paymentModes, isLoading: isLoadingPaymentModes } = usePaymentMethods();
+  const patientCategoryOptions: PatientCategoryOption[] = React.useMemo(() => {
+    return (patientCategories?.categories || []).map((category) => ({
+      text: category.text,
+      uuid: category.uuid,
+    }));
+  }, [patientCategories]);
+
   React.useEffect(() => {
     setAttributes(createVisitAttributesPayload());
   }, [paymentDetails, paymentMethods, insuranceSchema, policyNumber, patientCategory]);
 
   const createVisitAttributesPayload = () => {
     const { paymentDetails, paymentMethods, insuranceScheme, policyNumber, patientCategory } = getValues();
-    setPaymentMethod(paymentMethods);
+    setPaymentMethod?.(paymentMethods);
     const formPayload = [
       { uuid: patientCatergory.paymentDetails, value: paymentDetails },
       { uuid: patientCatergory.paymentMethods, value: paymentMethods },
@@ -156,12 +170,10 @@ const VisitAttributesForm: React.FC<VisitAttributesFormProps> = ({ setAttributes
               className={styles.sectionField}
               onChange={({ selectedItem }) => field.onChange(selectedItem?.uuid)}
               id="patientCategory"
-              items={[
-                { text: 'Child under 5', uuid: catergoryConcepts.childUnder5 },
-                { text: 'Student', uuid: catergoryConcepts.student },
-              ]}
+              items={patientCategoryOptions}
               itemToString={(item) => (item ? item.text : '')}
               titleText={t('patientCategory', 'Patient category')}
+              placeholder={t('selectPatientCategory', 'Select patient category')}
             />
           )}
         />

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -23,8 +23,23 @@ export const configSchema = {
       payingDetails: '44b34972-6630-4e5a-a9f6-a6eb0f109650',
       nonPayingDetails: 'f3fb2d88-cccd-422c-8766-be101ba7bd2e',
       insuranceDetails: 'beac329b-f1dc-4a33-9e7c-d95821a137a6',
-      childUnder5: '1528AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-      student: '159465AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    },
+  },
+
+  patientCategories: {
+    _type: Type.Object,
+    _description: 'Configurable patient categories for non-paying patients',
+    _default: {
+      categories: [
+        {
+          text: 'Child under 5',
+          uuid: '1528AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        },
+        {
+          text: 'Student',
+          uuid: '159465AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        },
+      ],
     },
   },
 
@@ -53,7 +68,7 @@ export const configSchema = {
   },
 
   pageSize: {
-    _type: Type.String,
+    _type: Type.Number,
     _description: 'The default page size',
     _default: 10,
   },

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -26,20 +26,12 @@ export const configSchema = {
     },
   },
 
-  patientCategories: {
+  nonPayingPatientCategories: {
     _type: Type.Object,
-    _description: 'Configurable patient categories for non-paying patients',
+    _description: 'Concept UUIDs for non-paying patient categories',
     _default: {
-      categories: [
-        {
-          text: 'Child under 5',
-          uuid: '1528AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-        },
-        {
-          text: 'Student',
-          uuid: '159465AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-        },
-      ],
+      childUnder5: '1528AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      student: '159465AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     },
   },
 
@@ -89,4 +81,5 @@ export interface ConfigObject {
   showEditBillButton: boolean;
   postBilledItems: Object;
   serviceTypes: Object;
+  nonPayingPatientCategories: Object;
 }


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
refactor: make patient categories configurable

Previously, patient categories were hardcoded in the VisitAttributesForm component. 
This change makes them configurable through the configuration system.

Changes:
- Added new patientCategories section to config schema
- Moved patient category options from component to configuration
- Updated VisitAttributesForm to use configured categories

Patient categories are now defined in config instead of the component. Implementers need to configure their categories in the config file.

## Screenshots

https://github.com/user-attachments/assets/77308fd7-461e-430d-a221-3bb14dc361b3


## Related Issue
https://openmrs.atlassian.net/browse/O3-4164

## Other
<!-- Anything not covered above -->
<!-- *None* -->
