### PR TITLE
(refactor) Move feature flag registration to routes.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { configSchema } from './config-schema';
 import { createDashboardLink } from '@openmrs/esm-patient-common-lib';
 import { createLeftPanelLink } from './left-panel-link.component';
 import { dashboardMeta } from './dashboard.meta';
-import { defineConfigSchema, getAsyncLifecycle, getSyncLifecycle, registerFeatureFlag } from '@openmrs/esm-framework';
+import { defineConfigSchema, getAsyncLifecycle, getSyncLifecycle } from '@openmrs/esm-framework';
 import appMenu from './billable-services/billable-services-menu-item/item.component';
 import BillableServiceHome from './billable-services/billable-services-home.component';
 import BillableServicesCardLink from './billable-services-admin-card-link.component';
@@ -19,12 +19,6 @@ const options = {
   featureName: 'billing',
   moduleName,
 };
-
-registerFeatureFlag(
-  'billing',
-  'Billing module',
-  'This feature introduces navigation links on the patient chart and home page to allow accessing the billing module features',
-);
 
 // t('billing', 'Billing')
 export const billingDashboardLink = getSyncLifecycle(

--- a/src/routes.json
+++ b/src/routes.json
@@ -7,7 +7,7 @@
   "pages": [
     {
       "component": "billableServicesHome",
-      "route":"billable-services"
+      "route": "billable-services"
     }
   ],
   "extensions": [
@@ -98,6 +98,13 @@
       "title": "billingForm",
       "component": "billingFormWorkspace",
       "type": "form"
+    }
+  ],
+  "featureFlags": [
+    {
+      "flagName": "billing",
+      "label": "Billing module",
+      "description": "This feature introduces navigation links on the patient chart and home page to allow accessing the billing module features"
     }
   ]
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary

This change standardizes feature flag management by moving registration logic from app entry points to the routes.json file. This aligns with recommended practice for feature flag registration.

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
