### PR TITLE
(refactor) Replace launchPatientWorkspace with launchWorkspace

### DIFF
--- a/src/bill-history/bill-history.component.tsx
+++ b/src/bill-history/bill-history.component.tsx
@@ -18,19 +18,13 @@ import {
   TableRow,
   Tile,
 } from '@carbon/react';
-import { isDesktop, useConfig, useLayoutType, usePagination } from '@openmrs/esm-framework';
-import {
-  CardHeader,
-  EmptyDataIllustration,
-  ErrorState,
-  launchPatientWorkspace,
-  usePaginationInfo,
-} from '@openmrs/esm-patient-common-lib';
+import { Add } from '@carbon/react/icons';
+import { isDesktop, launchWorkspace, useConfig, useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { CardHeader, EmptyDataIllustration, ErrorState, usePaginationInfo } from '@openmrs/esm-patient-common-lib';
+import { convertToCurrency } from '../helpers';
 import { useBills } from '../billing.resource';
 import InvoiceTable from '../invoice/invoice-table.component';
 import styles from './bill-history.scss';
-import { Add } from '@carbon/react/icons';
-import { convertToCurrency } from '../helpers';
 
 interface BillHistoryProps {
   patientUuid: string;
@@ -103,7 +97,7 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
             <EmptyDataIllustration />
           </div>
           <p className={styles.content}>There are no bills to display.</p>
-          <Button onClick={() => launchPatientWorkspace('billing-form-workspace')} kind="ghost">
+          <Button onClick={() => launchWorkspace('billing-form-workspace')} kind="ghost">
             {t('launchBillForm', 'Launch bill form')}
           </Button>
         </Tile>
@@ -114,7 +108,7 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
   return (
     <div>
       <CardHeader title={t('billingHistory', 'Billing History')}>
-        <Button renderIcon={Add} onClick={() => launchPatientWorkspace('billing-form-workspace', {})} kind="ghost">
+        <Button renderIcon={Add} onClick={() => launchWorkspace('billing-form-workspace', {})} kind="ghost">
           {t('addBill', 'Add bill item(s)')}
         </Button>
       </CardHeader>

--- a/src/bill-history/bill-history.test.tsx
+++ b/src/bill-history/bill-history.test.tsx
@@ -55,7 +55,6 @@ jest.mock('@openmrs/esm-patient-common-lib', () => ({
   CardHeader: jest.fn(({ children }) => <div>{children}</div>),
   EmptyDataIllustration: jest.fn(() => <div>Empty state illustration</div>),
   ErrorState: jest.fn(({ error }) => <div>Error: {error?.message}</div>),
-  launchPatientWorkspace: jest.fn(),
   usePaginationInfo: jest.fn(() => ({
     pageSizes: [10, 20, 30],
     currentPage: 1,


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR replaces the use of `launchPatientWorkspace` with `launchWorkspace`. This is following the removal of the `launchPatientWorkspace` function from the `openmrs/esm-patient-common-lib` package in https://github.com/openmrs/openmrs-esm-patient-chart/pull/2444.

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
