### PR TITLE
fix(billing): ensure printable invoice always renders in PDF

### DIFF
--- a/src/invoice/invoice.scss
+++ b/src/invoice/invoice.scss
@@ -80,11 +80,6 @@
 
 .printContainer {
   background-color: colors.$white;
-  display: none;
-
-  @media print {
-    display: block !important;
-  }
 }
 
 @media print {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
1.	Previously, PDFs sometimes showed empty table rows when printing invoices.
2.	The root cause was the `display: none` CSS on `.printContainer` combined with `@media print`. 
        React was already  conditionally rendering the <PrintableInvoice> component via `isPrinting`, so the CSS was                         redundant and caused timing issues in react-to-print.
3.    Fix : Remove `display: none`  from `.printContainer`. Now the component is rendered only when `isPrinting` is true, guaranteeing that the invoice content is always present in the PDF.


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
