### PR TITLE
(fix): Config schema for logo's alt should have a default

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -10,6 +10,7 @@ export const configSchema = {
     },
     alt: {
       _type: Type.String,
+      _default: '',
       _description:
         'The alternative text for the logo image, displayed when the image cannot be loaded or on hover. If not provided and src is empty, the default OpenMRS SVG sprite will be used.',
     },

--- a/src/invoice/printable-invoice/printable-invoice-header.component.tsx
+++ b/src/invoice/printable-invoice/printable-invoice-header.component.tsx
@@ -21,7 +21,7 @@ const PrintableInvoiceHeader: React.FC<PrintableInvoiceHeaderProps> = ({ patient
         <p className={styles.heading}>{t('invoice', 'Invoice')}</p>
         {logo && logo.src && !isEmpty(logo.src) ? (
           <img className={styles.img} src={logo.src} alt={logo.alt} />
-        ) : logo && logo.alt ? (
+        ) : logo && logo.alt && !isEmpty(logo.alt) ? (
           logo.alt
         ) : (
           // OpenMRS Logo


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates the config schema so that the alt text for the logo has a default, which is required for any config.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
