### PR TITLE
(fix): Interpolate logo url and display correct line item in invoice

### DIFF
--- a/src/invoice/invoice.component.tsx
+++ b/src/invoice/invoice.component.tsx
@@ -133,9 +133,11 @@ const Invoice: React.FC = () => {
       <InvoiceTable bill={bill} isLoadingBill={isLoadingBill} onSelectItem={handleSelectItem} />
       <Payments bill={bill} mutate={mutate} selectedLineItems={selectedLineItems} />
 
-      <div className={styles.printContainer}>
-        <PrintableInvoice bill={bill} patient={patient} defaultFacility={data} componentRef={componentRef} />
-      </div>
+      {bill && patient && (
+        <div className={styles.printContainer}>
+          <PrintableInvoice bill={bill} patient={patient} defaultFacility={data} componentRef={componentRef} />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/invoice/printable-invoice/printable-invoice-header.component.tsx
+++ b/src/invoice/printable-invoice/printable-invoice-header.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { type PatientDetails } from '../../types';
-import { type SessionLocation, useConfig } from '@openmrs/esm-framework';
+import { type SessionLocation, useConfig, interpolateUrl } from '@openmrs/esm-framework';
 import { useTranslation } from 'react-i18next';
 import type { BillingConfig } from '../../config-schema';
 import styles from './printable-invoice-header.scss';
@@ -20,7 +20,7 @@ const PrintableInvoiceHeader: React.FC<PrintableInvoiceHeaderProps> = ({ patient
       <div className={styles.printableHeader}>
         <p className={styles.heading}>{t('invoice', 'Invoice')}</p>
         {logo?.src && !isEmpty(logo.src) ? (
-          <img className={styles.img} src={logo.src} alt={logo.alt} />
+          <img className={styles.img} src={interpolateUrl(logo.src)} alt={logo.alt} />
         ) : logo?.alt && !isEmpty(logo.alt) ? (
           logo.alt
         ) : (

--- a/src/invoice/printable-invoice/printable-invoice.component.tsx
+++ b/src/invoice/printable-invoice/printable-invoice.component.tsx
@@ -39,7 +39,7 @@ const PrintableInvoice: React.FC<PrintableInvoiceProps> = ({ bill, patient, comp
     bill?.lineItems?.map((item) => {
       return {
         id: `${item.uuid}`,
-        billItem: item.item,
+        billItem: item.billableService ?? item.item,
         quantity: item.quantity,
         price: item.price,
         total: item.price * item.quantity,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR does the following fixes:
1. Loads the printable invoice component only when its dependencies(patient and bill) has loaded
2. Interpolates the logo url so that configured urls like `${openmrsSpaBase}/logo.png` would work
3. Updates the property to be displayed for each invoice item so that it is no longer empty

## Screenshots
<!-- Required if you are making UI changes. -->
Before fix:
<img width="1178" height="783" alt="Screenshot 2025-09-25 at 2 58 04 PM" src="https://github.com/user-attachments/assets/da87606c-b9aa-496f-abd1-c2e1a09af9d9" />

After fix:
<img width="1178" height="783" alt="Screenshot 2025-09-25 at 2 53 07 PM" src="https://github.com/user-attachments/assets/8b16227d-966d-40ad-82ee-b14b828b58f7" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
