### PR TITLE
fix: Remove support for selectable line items

### DIFF
--- a/src/bill-history/bill-history.component.tsx
+++ b/src/bill-history/bill-history.component.tsx
@@ -155,7 +155,7 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
                         {row.isExpanded ? (
                           <TableExpandedRow className={styles.expandedRow} colSpan={headers.length + 1}>
                             <div className={styles.container} key={i}>
-                              <InvoiceTable bill={currentBill} isSelectable={false} />
+                              <InvoiceTable bill={currentBill} />
                             </div>
                           </TableExpandedRow>
                         ) : (

--- a/src/invoice/invoice-table.component.tsx
+++ b/src/invoice/invoice-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import fuzzy from 'fuzzy';
 import {
@@ -13,7 +13,6 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-  TableSelectRow,
   TableToolbarSearch,
   Tile,
   type DataTableRow,
@@ -22,32 +21,22 @@ import { Edit } from '@carbon/react/icons';
 import { isDesktop, showModal, useConfig, useDebounce, useLayoutType } from '@openmrs/esm-framework';
 import { type LineItem, type MappedBill } from '../types';
 import { convertToCurrency } from '../helpers';
+import type { BillingConfig } from '../config-schema';
 import styles from './invoice-table.scss';
 
 type InvoiceTableProps = {
   bill: MappedBill;
-  isSelectable?: boolean;
   isLoadingBill?: boolean;
-  onSelectItem?: (selectedLineItems: LineItem[]) => void;
 };
 
-const InvoiceTable: React.FC<InvoiceTableProps> = ({ bill, isSelectable = true, isLoadingBill, onSelectItem }) => {
+const InvoiceTable: React.FC<InvoiceTableProps> = ({ bill, isLoadingBill }) => {
   const { t } = useTranslation();
-  const { defaultCurrency, showEditBillButton } = useConfig();
+  const { defaultCurrency, showEditBillButton } = useConfig<BillingConfig>();
   const layout = useLayoutType();
   const lineItems = useMemo(() => bill?.lineItems ?? [], [bill?.lineItems]);
-  const paidLineItems = useMemo(() => lineItems?.filter((item) => item.paymentStatus === 'PAID') ?? [], [lineItems]);
   const responsiveSize = isDesktop(layout) ? 'sm' : 'lg';
-
-  const [selectedLineItems, setSelectedLineItems] = useState(paidLineItems ?? []);
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearchTerm = useDebounce(searchTerm);
-
-  useEffect(() => {
-    if (onSelectItem) {
-      onSelectItem(selectedLineItems);
-    }
-  }, [selectedLineItems, onSelectItem]);
 
   const filteredLineItems = useMemo(() => {
     if (!debouncedSearchTerm) {
@@ -135,23 +124,10 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({ bill, isSelectable = true, 
     );
   }
 
-  const handleRowSelection = (row: typeof DataTableRow, checked: boolean) => {
-    const matchingRow = filteredLineItems.find((item) => item.uuid === row.id);
-    let newSelectedLineItems;
-
-    if (checked) {
-      newSelectedLineItems = [...selectedLineItems, matchingRow];
-    } else {
-      newSelectedLineItems = selectedLineItems.filter((item) => item.uuid !== row.id);
-    }
-    setSelectedLineItems(newSelectedLineItems);
-    onSelectItem(newSelectedLineItems);
-  };
-
   return (
     <>
-      <DataTable headers={tableHeaders} isSortable rows={tableRows} size={responsiveSize} useZebraStyles>
-        {({ rows, headers, getRowProps, getSelectionProps, getTableProps, getToolbarProps }) => (
+      <DataTable headers={tableHeaders} rows={tableRows} size={responsiveSize} useZebraStyles>
+        {({ rows, headers, getRowProps, getTableProps }) => (
           <TableContainer
             description={
               <span className={styles.tableDescription}>
@@ -172,7 +148,6 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({ bill, isSelectable = true, 
               className={`${styles.invoiceTable} billingTable`}>
               <TableHead>
                 <TableRow>
-                  {rows.length > 1 && isSelectable ? <TableHeader /> : null}
                   {headers.map((header) => (
                     <TableHeader key={header.key}>{header.header}</TableHeader>
                   ))}
@@ -186,18 +161,6 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({ bill, isSelectable = true, 
                       {...getRowProps({
                         row,
                       })}>
-                      {rows.length > 1 && isSelectable && (
-                        <TableSelectRow
-                          aria-label="Select row"
-                          {...getSelectionProps({ row })}
-                          disabled={tableRows[index].status === 'PAID'}
-                          onChange={(checked: boolean) => handleRowSelection(row, checked)}
-                          checked={
-                            tableRows[index].status === 'PAID' ||
-                            Boolean(selectedLineItems?.find((item) => item?.uuid === row?.id))
-                          }
-                        />
-                      )}
                       {row.cells.map((cell) => (
                         <TableCell key={cell.id}>{cell.value}</TableCell>
                       ))}

--- a/src/invoice/invoice-table.test.tsx
+++ b/src/invoice/invoice-table.test.tsx
@@ -110,17 +110,6 @@ describe('InvoiceTable', () => {
     expect(screen.getByText('Item 2')).toBeInTheDocument();
   });
 
-  it('correctly handles row selection', async () => {
-    const user = userEvent.setup();
-    const onSelectItem = jest.fn();
-    render(<InvoiceTable bill={bill} onSelectItem={onSelectItem} />);
-
-    const checkboxes = screen.getAllByLabelText('Select row');
-    await user.click(checkboxes[0]);
-
-    expect(onSelectItem).toHaveBeenCalledWith([bill.lineItems[0]]);
-  });
-
   it('resets isRedirecting to false after timeout', async () => {
     const user = userEvent.setup();
     render(<InvoiceTable bill={bill} />);

--- a/src/invoice/invoice.component.tsx
+++ b/src/invoice/invoice.component.tsx
@@ -12,7 +12,6 @@ import PrintableInvoice from './printable-invoice/printable-invoice.component';
 import { ErrorState } from '@openmrs/esm-patient-common-lib';
 import { convertToCurrency } from '../helpers';
 import { useBill, useDefaultFacility } from '../billing.resource';
-import { type LineItem } from '../types';
 import type { BillingConfig } from '../config-schema';
 import styles from './invoice.scss';
 
@@ -28,13 +27,9 @@ const Invoice: React.FC = () => {
   const { patient, isLoading: isLoadingPatient } = usePatient(patientUuid);
   const { bill, isLoading: isLoadingBill, error, mutate } = useBill(billUuid);
   const [isPrinting, setIsPrinting] = useState(false);
-  const [selectedLineItems, setSelectedLineItems] = useState<LineItem[]>([]);
   const componentRef = useRef<HTMLDivElement>(null);
   const onBeforeGetContentResolve = useRef<(() => void) | null>(null);
   const { defaultCurrency } = useConfig<BillingConfig>();
-  const handleSelectItem = (lineItems: LineItem[]) => {
-    setSelectedLineItems(lineItems);
-  };
 
   const handleAfterPrint = useCallback(() => {
     onBeforeGetContentResolve.current = null;
@@ -65,11 +60,6 @@ const Invoice: React.FC = () => {
       onBeforeGetContentResolve.current();
     }
   }, [isPrinting]);
-
-  useEffect(() => {
-    const unPaidLineItems = bill?.lineItems?.filter((item) => item.paymentStatus === 'PENDING') ?? [];
-    setSelectedLineItems(unPaidLineItems);
-  }, [bill?.lineItems]);
 
   // Do not remove this comment. Adds the translation keys for the invoice details
   /**
@@ -130,8 +120,8 @@ const Invoice: React.FC = () => {
         </div>
       </div>
 
-      <InvoiceTable bill={bill} isLoadingBill={isLoadingBill} onSelectItem={handleSelectItem} />
-      <Payments bill={bill} mutate={mutate} selectedLineItems={selectedLineItems} />
+      <InvoiceTable bill={bill} isLoadingBill={isLoadingBill} />
+      <Payments bill={bill} mutate={mutate} />
 
       {bill && patient && (
         <div className={styles.printContainer}>

--- a/src/invoice/payments/payment-form/payment-form.component.tsx
+++ b/src/invoice/payments/payment-form/payment-form.component.tsx
@@ -10,19 +10,12 @@ import styles from './payment-form.scss';
 
 type PaymentFormProps = {
   disablePayment: boolean;
-  clientBalance: number;
-  isSingleLineItemSelected: boolean;
   isSingleLineItem: boolean;
 };
 
 const DEFAULT_PAYMENT = { method: '', amount: 0, referenceCode: '' };
 
-const PaymentForm: React.FC<PaymentFormProps> = ({
-  disablePayment,
-  clientBalance,
-  isSingleLineItemSelected,
-  isSingleLineItem,
-}) => {
+const PaymentForm: React.FC<PaymentFormProps> = ({ disablePayment, isSingleLineItem }) => {
   const { t } = useTranslation();
   const {
     control,
@@ -119,7 +112,7 @@ const PaymentForm: React.FC<PaymentFormProps> = ({
           </div>
         ))}
       <Button
-        disabled={disablePayment || (!isSingleLineItem && !isSingleLineItemSelected)}
+        disabled={disablePayment}
         size="md"
         onClick={handleAppendPaymentMode}
         className={styles.paymentButtons}

--- a/src/invoice/payments/payment-form/payment-form.test.tsx
+++ b/src/invoice/payments/payment-form/payment-form.test.tsx
@@ -31,12 +31,7 @@ describe('PaymentForm Component', () => {
 
     render(
       <Wrapper>
-        <PaymentForm
-          disablePayment={false}
-          clientBalance={100}
-          isSingleLineItemSelected={false}
-          isSingleLineItem={false}
-        />
+        <PaymentForm disablePayment={false} isSingleLineItem={false} />
       </Wrapper>,
     );
 
@@ -53,12 +48,7 @@ describe('PaymentForm Component', () => {
 
     render(
       <Wrapper>
-        <PaymentForm
-          disablePayment={false}
-          clientBalance={100}
-          isSingleLineItemSelected={false}
-          isSingleLineItem={false}
-        />
+        <PaymentForm disablePayment={false} isSingleLineItem={false} />
       </Wrapper>,
     );
 
@@ -75,12 +65,7 @@ describe('PaymentForm Component', () => {
 
     render(
       <Wrapper>
-        <PaymentForm
-          disablePayment={false}
-          clientBalance={100}
-          isSingleLineItemSelected={false}
-          isSingleLineItem={true}
-        />
+        <PaymentForm disablePayment={false} isSingleLineItem={true} />
       </Wrapper>,
     );
 
@@ -103,12 +88,7 @@ describe('PaymentForm Component', () => {
 
     render(
       <Wrapper>
-        <PaymentForm
-          disablePayment={false}
-          clientBalance={100}
-          isSingleLineItemSelected={true}
-          isSingleLineItem={false}
-        />
+        <PaymentForm disablePayment={false} isSingleLineItem={false} />
       </Wrapper>,
     );
 
@@ -128,12 +108,7 @@ describe('PaymentForm Component', () => {
 
     render(
       <Wrapper>
-        <PaymentForm
-          disablePayment={true}
-          clientBalance={100}
-          isSingleLineItemSelected={true}
-          isSingleLineItem={false}
-        />
+        <PaymentForm disablePayment={true} isSingleLineItem={false} />
       </Wrapper>,
     );
 
@@ -151,12 +126,7 @@ describe('PaymentForm Component', () => {
 
     render(
       <Wrapper>
-        <PaymentForm
-          disablePayment={false}
-          clientBalance={100}
-          isSingleLineItemSelected={true}
-          isSingleLineItem={false}
-        />
+        <PaymentForm disablePayment={false} isSingleLineItem={false} />
       </Wrapper>,
     );
 

--- a/src/invoice/payments/payments.component.tsx
+++ b/src/invoice/payments/payments.component.tsx
@@ -6,20 +6,19 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { navigate, showSnackbar, useConfig, useVisit } from '@openmrs/esm-framework';
 import { Button } from '@carbon/react';
 import { CardHeader } from '@openmrs/esm-patient-common-lib';
-import { type LineItem, type MappedBill } from '../../types';
-import { convertToCurrency } from '../../helpers';
-import { createPaymentPayload } from './utils';
-import { processBillPayment } from '../../billing.resource';
 import { InvoiceBreakDown } from './invoice-breakdown/invoice-breakdown.component';
 import PaymentHistory from './payment-history/payment-history.component';
 import PaymentForm from './payment-form/payment-form.component';
-import { updateBillVisitAttribute } from './payment.resource';
-import styles from './payments.scss';
+import { convertToCurrency } from '../../helpers';
+import { createPaymentPayload } from './utils';
+import { processBillPayment } from '../../billing.resource';
 import { useBillableServices } from '../../billable-services/billable-service.resource';
+import { updateBillVisitAttribute } from './payment.resource';
+import { type MappedBill } from '../../types';
+import styles from './payments.scss';
 
 type PaymentProps = {
   bill: MappedBill;
-  selectedLineItems: Array<LineItem>;
   mutate: () => void;
 };
 
@@ -29,7 +28,7 @@ export type PaymentFormValue = {
   payment: Array<Payment>;
 };
 
-const Payments: React.FC<PaymentProps> = ({ bill, mutate, selectedLineItems }) => {
+const Payments: React.FC<PaymentProps> = ({ bill, mutate }) => {
   const { t } = useTranslation();
   const { billableServices, isLoading, isValidating, error } = useBillableServices();
   const paymentSchema = z.object({
@@ -54,25 +53,23 @@ const Payments: React.FC<PaymentProps> = ({ bill, mutate, selectedLineItems }) =
     control: methods.control,
   });
 
-  const selectedLineItemsTotal = selectedLineItems.reduce((total, item) => total + item.price * item.quantity, 0);
-  const totalAmountTendered = formValues?.reduce((curr: number, prev) => curr + Number(prev.amount) ?? 0, 0) ?? 0;
-  const amountDue = bill ? bill.totalAmount - selectedLineItemsTotal : 0;
-  const clientBalance = bill ? bill.totalAmount - (bill.tenderedAmount + totalAmountTendered) : 0;
-
   const handleNavigateToBillingDashboard = () =>
     navigate({
       to: window.getOpenmrsSpaBase() + 'home/billing',
     });
 
+  const amountDue = bill.totalAmount - bill.tenderedAmount;
+
   const handleProcessPayment = () => {
     if (bill) {
+      const amountBeingTendered = formValues?.reduce((acc, curr) => acc + Number(curr.amount), 0);
+      const amountRemaining = amountDue - amountBeingTendered;
       const paymentPayload = createPaymentPayload(
         bill,
         bill?.patientUuid,
         formValues,
-        amountDue,
+        amountRemaining,
         billableServices,
-        selectedLineItems,
       );
       paymentPayload.payments.forEach((payment) => {
         payment.dateCreated = new Date(payment.dateCreated);
@@ -103,9 +100,6 @@ const Payments: React.FC<PaymentProps> = ({ bill, mutate, selectedLineItems }) =
     return null;
   }
 
-  const amountDueLabel = selectedLineItems.length ? t('amountDue', 'Amount Due') : t('clientBalance', 'Client Balance');
-  const amountDueValue = selectedLineItems.length ? amountDue : clientBalance;
-
   return (
     <FormProvider {...methods}>
       <div className={styles.wrapper}>
@@ -115,12 +109,7 @@ const Payments: React.FC<PaymentProps> = ({ bill, mutate, selectedLineItems }) =
           </CardHeader>
           <div>
             {bill && <PaymentHistory bill={bill} />}
-            <PaymentForm
-              disablePayment={clientBalance <= 0}
-              clientBalance={clientBalance}
-              isSingleLineItemSelected={selectedLineItems.length > 0}
-              isSingleLineItem={bill.lineItems.length === 1}
-            />
+            <PaymentForm disablePayment={amountDue <= 0} isSingleLineItem={bill.lineItems.length === 1} />
           </div>
         </div>
         <div className={styles.divider} />
@@ -131,13 +120,13 @@ const Payments: React.FC<PaymentProps> = ({ bill, mutate, selectedLineItems }) =
           />
           <InvoiceBreakDown
             label={t('totalTendered', 'Total Tendered')}
-            value={convertToCurrency(bill?.tenderedAmount + totalAmountTendered, defaultCurrency)}
+            value={convertToCurrency(bill.tenderedAmount, defaultCurrency)}
           />
           <InvoiceBreakDown label={t('discount', 'Discount')} value={'--'} />
           <InvoiceBreakDown
-            hasBalance={amountDueValue < 0}
-            label={amountDueLabel}
-            value={convertToCurrency(amountDueValue < 0 ? -amountDueValue : amountDueValue, defaultCurrency)}
+            hasBalance={amountDue < 0}
+            label={t('amountDue', 'Amount Due')}
+            value={convertToCurrency(amountDue < 0 ? -amountDue : amountDue, defaultCurrency)}
           />
           <div className={styles.processPayments}>
             <Button onClick={handleNavigateToBillingDashboard} kind="secondary">

--- a/src/invoice/payments/payments.test.tsx
+++ b/src/invoice/payments/payments.test.tsx
@@ -108,14 +108,14 @@ describe('Payments', () => {
   });
 
   it('renders payment form and history', () => {
-    render(<Payments bill={mockBill} mutate={mockMutate} selectedLineItems={mockSelectedLineItems} />);
+    render(<Payments bill={mockBill} mutate={mockMutate} />);
     expect(screen.getByText('Payments')).toBeInTheDocument();
     expect(screen.getByText('Total Amount:')).toBeInTheDocument();
     expect(screen.getByText('Total Tendered:')).toBeInTheDocument();
   });
 
   it('calculates and displays correct amounts', () => {
-    render(<Payments bill={mockBill} mutate={mockMutate} selectedLineItems={mockSelectedLineItems} />);
+    render(<Payments bill={mockBill} mutate={mockMutate} />);
     const amountElements = screen.getAllByText('$1000.00');
     expect(amountElements[amountElements.length - 3]).toBeInTheDocument();
     expect(amountElements[amountElements.length - 2]).toBeInTheDocument();
@@ -123,12 +123,12 @@ describe('Payments', () => {
   });
 
   it('disables Process Payment button when form is invalid', () => {
-    render(<Payments bill={mockBill} mutate={mockMutate} selectedLineItems={mockSelectedLineItems} />);
+    render(<Payments bill={mockBill} mutate={mockMutate} />);
     expect(screen.getByText('Process Payment')).toBeDisabled();
   });
 
   it('navigates to billing dashboard when Discard is clicked', async () => {
-    render(<Payments bill={mockBill} mutate={mockMutate} selectedLineItems={mockSelectedLineItems} />);
+    render(<Payments bill={mockBill} mutate={mockMutate} />);
     await userEvent.click(screen.getByText('Discard'));
     expect(navigate).toHaveBeenCalled();
   });

--- a/translations/en.json
+++ b/translations/en.json
@@ -54,7 +54,6 @@
   "cashPointUuidPlaceholder": "Enter UUID",
   "checkFilters": "Check the filters above",
   "clearSearchInput": "Clear search input",
-  "clientBalance": "Client Balance",
   "confirmDeleteMessage": "Are you sure you want to delete this payment mode? Proceed cautiously.",
   "createdSuccessfully": "Billable service created successfully",
   "currentPrice": "Current price",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR removes the ability to select line items of a bill when recording payments. This is because we currently don't have a way of recording whether a payment was made for a specific line item, it is only recorded against the entire bill, so we can't keep track of partial payments made against line items.
Line items get the payment status `PAID` when the entire bill is paid in full.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/5bceadc3-d977-44df-b562-8194fdd67acb



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
