### PR TITLE
(fix) Bill payment status should be set by the backend

### DIFF
--- a/src/invoice/payments/utils.ts
+++ b/src/invoice/payments/utils.ts
@@ -42,7 +42,6 @@ export const createPaymentPayload = (
     lineItems: updatedLineItems,
     payments: [...updatedPayments],
     patient: patientUuid,
-    status: paymentStatus,
   };
 
   return processedPayment;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
When recording a payment that would complete the total in a bill, the frontend tried to set the `paymentStatus` to `PAID` in the payload, but the backend already does this and has the paymentStatus set to a non-mutable field, so the server would return an error. This makes it so that we let the backend take care of updating the bill’s payment status.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
