### PR TITLE
(chore) Update bot PAT secret name to OMRS_BOT_GH_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
     uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/release-frontend-module.yml@main
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      BOT_PAT: ${{ secrets.BOT_PAT }}
+      BOT_PAT: ${{ secrets.OMRS_BOT_GH_TOKEN }}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

Updates the GitHub Actions release workflow to reference the renamed org-level bot PAT secret (`OMRS_BOT_GH_TOKEN`) instead of the old `BOT_PAT` name, since that is the secret name used by the OWASP action as well. Hopefully this was why the job was failing.

## Screenshots
<!-- Not applicable — workflow-only change -->

## Related Issue
<!-- No Jira ticket — infrastructure/secret rename -->

## Other
<!-- Nothing else to note -->