### PR TITLE
(fix) O3-5601: Lowercase billing patient chart dashboard path

### DIFF
--- a/e2e/specs/billing-dashboard.spec.ts
+++ b/e2e/specs/billing-dashboard.spec.ts
@@ -57,7 +57,7 @@ test.describe('Billing Dashboard workflow', () => {
     let billUuid: string;
 
     await test.step('Given I have created and saved a bill', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
 
       const createBillButton = page.getByRole('button', { name: /launch bill form|add bill|create bill/i });
       await createBillButton.click();
@@ -227,7 +227,7 @@ test.describe('Billing Dashboard workflow', () => {
     let billUuid: string;
 
     await test.step('Given a bill has been created for a patient (PENDING status)', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
 
       const createBillButton = page.getByRole('button', { name: /launch bill form|add bill|create bill/i });
       await createBillButton.click();

--- a/e2e/specs/billing-patient-chart.spec.ts
+++ b/e2e/specs/billing-patient-chart.spec.ts
@@ -51,7 +51,7 @@ test.describe('Billing: Patient Chart workflow', () => {
     let billUuid: string;
 
     await test.step('When I navigate to the Billing history page', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
     });
 
     await test.step('And I launch the Create Bill form', async () => {
@@ -161,7 +161,7 @@ test.describe('Billing: Patient Chart workflow', () => {
     let billUuid: string;
 
     await test.step('When I navigate to the patient billing history', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
     });
 
     await test.step('And I click the Launch bill form button', async () => {
@@ -217,7 +217,7 @@ test.describe('Billing: Patient Chart workflow', () => {
     });
 
     await test.step('When I navigate to the patient billing history', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
     });
 
     await test.step('And I click the Launch bill form button', async () => {
@@ -249,7 +249,7 @@ test.describe('Billing: Patient Chart workflow', () => {
     const patientUuid = patient.uuid;
 
     await test.step('When I navigate to the patient billing history', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
     });
 
     await test.step('And I click the Launch bill form button', async () => {
@@ -295,7 +295,7 @@ test.describe('Billing: Patient Chart workflow', () => {
     let partialAmount: number;
 
     await test.step('Given I have created and saved a bill', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
 
       const createBillButton = page.getByRole('button', { name: /launch bill form|add bill|create bill/i });
       await createBillButton.click();
@@ -417,7 +417,7 @@ test.describe('Billing: Patient Chart workflow', () => {
     const expectedTotal = expectedServicePrice * quantity;
 
     await test.step('When I navigate to the Billing history page', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
     });
 
     await test.step('And I launch the Create Bill form', async () => {
@@ -552,7 +552,7 @@ test.describe('Billing: Patient Chart workflow', () => {
     let paymentAmount2: number;
 
     await test.step('Given I have created a bill', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
 
       const createBillButton = page.getByRole('button', { name: /launch bill form|add bill|create bill/i });
       await createBillButton.click();
@@ -663,7 +663,7 @@ test.describe('Billing: Patient Chart workflow', () => {
     const expectedTotal = expectedServicePrice * quantity;
 
     await test.step('Given I create a bill with a service quantity of 2', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
 
       const createBillButton = page.getByRole('button', { name: /launch bill form|add bill|create bill/i });
       await createBillButton.click();
@@ -773,7 +773,7 @@ test.describe('Billing: Patient Chart workflow', () => {
     let billUuid: string;
 
     await test.step('Given I create and save a bill', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
 
       const createBillButton = page.getByRole('button', { name: /launch bill form|add bill|create bill/i });
       await createBillButton.click();
@@ -830,7 +830,7 @@ test.describe('Billing: Patient Chart workflow', () => {
     let initialTotalAmount: number;
 
     await test.step('Given I have created a bill with a line item', async () => {
-      await page.goto(`patient/${patientUuid}/chart/Billing history`);
+      await page.goto(`patient/${patientUuid}/chart/billing-history`);
 
       const createBillButton = page.getByRole('button', { name: /launch bill form|add bill|create bill/i });
       await createBillButton.click();

--- a/src/dashboard.meta.ts
+++ b/src/dashboard.meta.ts
@@ -10,5 +10,5 @@ export const dashboardMeta: Omit<DashboardExtensionProps, 'basePath'> & {
   title: 'billingHistory',
   hideDashboardTitle: true,
   icon: 'omrs-icon-money',
-  path: 'Billing history',
+  path: 'billing-history',
 };

--- a/src/routes.json
+++ b/src/routes.json
@@ -44,7 +44,7 @@
         "columns": 1,
         "columnSpan": 1,
         "slot": "patient-chart-billing-dashboard-slot",
-        "path": "Billing history"
+        "path": "billing-history"
       }
     },
     {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

Changes the patient chart billing dashboard path from `Billing history` to `billing-history`. The space in the old path was being URL-encoded as `Billing%20history` in the browser.

This is part of the broader effort to use clean, lowercase, hyphenated URL paths for dashboard slugs across O3. The patient-chart PR includes a legacy alias map that ensures old URLs continue to resolve correctly, so this change should be merged after that PR lands.

## Screenshots

N/A (no visual changes, only URL path)

## Related Issue

https://openmrs.atlassian.net/browse/O3-5601

## Other

Depends on https://github.com/openmrs/openmrs-esm-patient-chart/pull/3217 being merged first (provides the legacy alias map for backward compatibility).