### PR TITLE
(chore) Set npm publish registry explicitly in .yarnrc.yml

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,6 +4,8 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
+npmPublishRegistry: "https://registry.npmjs.org"
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-outdated.cjs
     spec: "https://mskelton.dev/yarn-outdated/v3"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Explicitly sets `npmPublishRegistry` to `https://registry.npmjs.org` in `.yarnrc.yml` to ensure packages are published to the public npm registry.

## Screenshots

## Related Issue

N/A

## Other

N/A