### PR TITLE
(fix) O3-5714: Only render payment status tag on the chart itself

### DIFF
--- a/src/payment-status-tag/payment-status-tag.component.tsx
+++ b/src/payment-status-tag/payment-status-tag.component.tsx
@@ -13,29 +13,38 @@ import styles from './payment-status-tag.scss';
  * t('UNPAID', 'UNPAID')
  */
 
-type PaymentStatusTagProps = { patientUuid: string };
+type PaymentStatusTagProps = {
+  patientUuid: string;
+  renderedFrom: string;
+};
 
-const PaymentStatusTag: React.FC<PaymentStatusTagProps> = ({ patientUuid }) => {
+const PaymentStatusTag: React.FC<PaymentStatusTagProps> = ({ patientUuid, renderedFrom }) => {
+  const isPatientChart = renderedFrom === 'patient-chart';
+
+  if (!isPatientChart) {
+    return null;
+  }
+
+  return <PaymentStatusTagInner patientUuid={patientUuid} />;
+};
+
+const PaymentStatusTagInner: React.FC<Omit<PaymentStatusTagProps, 'renderedFrom'>> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const { paymentStatus, isLoading, error } = usePatientPaymentStatus(patientUuid);
-  return (
-    <>
-      {!isLoading && !error && paymentStatus && paymentStatus.status !== 'UNKNOWN' && (
-        <Toggletip className={styles.tag}>
-          <ToggletipButton label={t(paymentStatus.status, paymentStatus.status)}>
-            <Tag type={paymentStatus.status === 'PAID' ? 'green' : 'red'}>
-              {t(paymentStatus.status, paymentStatus.status)}
-            </Tag>
-          </ToggletipButton>
-          <ToggletipContent>
-            <div role="tooltip">
-              <p>{paymentStatus.reason}</p>
-            </div>
-          </ToggletipContent>
-        </Toggletip>
-      )}
-    </>
-  );
+  return !isLoading && !error && paymentStatus && paymentStatus.status !== 'UNKNOWN' ? (
+    <Toggletip className={styles.tag}>
+      <ToggletipButton label={t(paymentStatus.status, paymentStatus.status)}>
+        <Tag type={paymentStatus.status === 'PAID' ? 'green' : 'red'}>
+          {t(paymentStatus.status, paymentStatus.status)}
+        </Tag>
+      </ToggletipButton>
+      <ToggletipContent>
+        <div role="tooltip">
+          <p>{paymentStatus.reason}</p>
+        </div>
+      </ToggletipContent>
+    </Toggletip>
+  ) : null;
 };
 
 export default PaymentStatusTag;

--- a/src/payment-status-tag/payment-status-tag.test.tsx
+++ b/src/payment-status-tag/payment-status-tag.test.tsx
@@ -21,7 +21,7 @@ describe('PaymentStatusTag', () => {
       isValidating: false,
       mutate: vi.fn(),
     });
-    const { container } = render(<PaymentStatusTag patientUuid={patientUuid} />);
+    const { container } = render(<PaymentStatusTag patientUuid={patientUuid} renderedFrom="patient-chart" />);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -33,7 +33,7 @@ describe('PaymentStatusTag', () => {
       isValidating: false,
       mutate: vi.fn(),
     });
-    const { container } = render(<PaymentStatusTag patientUuid={patientUuid} />);
+    const { container } = render(<PaymentStatusTag patientUuid={patientUuid} renderedFrom="patient-chart" />);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -45,7 +45,7 @@ describe('PaymentStatusTag', () => {
       isValidating: false,
       mutate: vi.fn(),
     });
-    const { container } = render(<PaymentStatusTag patientUuid={patientUuid} />);
+    const { container } = render(<PaymentStatusTag patientUuid={patientUuid} renderedFrom="patient-chart" />);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -57,7 +57,19 @@ describe('PaymentStatusTag', () => {
       isValidating: false,
       mutate: vi.fn(),
     });
-    const { container } = render(<PaymentStatusTag patientUuid={patientUuid} />);
+    const { container } = render(<PaymentStatusTag patientUuid={patientUuid} renderedFrom="patient-chart" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when not in patient-chart status', () => {
+    mockUsePatientPaymentStatus.mockReturnValue({
+      paymentStatus: { status: 'PAID', reason: 'Status could not be determined' },
+      isLoading: false,
+      error: undefined,
+      isValidating: false,
+      mutate: vi.fn(),
+    });
+    const { container } = render(<PaymentStatusTag patientUuid={patientUuid} renderedFrom="patient-search" />);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -69,7 +81,7 @@ describe('PaymentStatusTag', () => {
       isValidating: false,
       mutate: vi.fn(),
     });
-    render(<PaymentStatusTag patientUuid={patientUuid} />);
+    render(<PaymentStatusTag patientUuid={patientUuid} renderedFrom="patient-chart" />);
     expect(screen.getByText('PAID')).toBeInTheDocument();
     expect(screen.getByText('Bill fully settled')).toBeInTheDocument();
   });
@@ -82,7 +94,7 @@ describe('PaymentStatusTag', () => {
       isValidating: false,
       mutate: vi.fn(),
     });
-    render(<PaymentStatusTag patientUuid={patientUuid} />);
+    render(<PaymentStatusTag patientUuid={patientUuid} renderedFrom="patient-chart" />);
     expect(screen.getByText('UNPAID')).toBeInTheDocument();
     expect(screen.getByText('Outstanding balance of 500')).toBeInTheDocument();
   });
@@ -95,7 +107,7 @@ describe('PaymentStatusTag', () => {
       isValidating: true,
       mutate: vi.fn(),
     });
-    render(<PaymentStatusTag patientUuid={patientUuid} />);
+    render(<PaymentStatusTag patientUuid={patientUuid} renderedFrom="patient-chart" />);
     expect(screen.getByText('PAID')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Simply hides the payment status bill outside of the patient-chart context with the aim of not making additional requests in the patient search if we don't need to.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-5714

## Other
<!-- Anything not covered above -->

See openmrs/openmrs-esm-patient-management#2554. The change here is basically the same as the change in that PR for queue status.
