### PR TITLE
(fix) O3-5706: Fix paying radio being unclickable when start visit form is opened from appointments page

### DIFF
--- a/src/billing-form/visit-attributes/visit-attributes-form.component.tsx
+++ b/src/billing-form/visit-attributes/visit-attributes-form.component.tsx
@@ -148,11 +148,15 @@ const VisitAttributesForm: React.FC<VisitAttributesFormProps> = ({ setAttributes
             name="payment-details"
             onChange={(selected) => field.onChange(selected)}
             orientation="vertical">
-            <RadioButton labelText={t('paying', 'Paying')} value={categoryConcepts.payingDetails} id="radio-1" />
+            <RadioButton
+              labelText={t('paying', 'Paying')}
+              value={categoryConcepts.payingDetails}
+              id="payment-details-paying"
+            />
             <RadioButton
               labelText={t('nonPaying', 'Non paying')}
               value={categoryConcepts.nonPayingDetails}
-              id="radio-2"
+              id="payment-details-non-paying"
             />
           </RadioButtonGroup>
         )}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The "Paying" radio button in the billing details section of the start visit form could not be clicked when the form was launched from the appointments page check-in button.

**Root cause:** `visit-attributes-form.component.tsx` used hardcoded `id="radio-1"` for the Paying radio and `id="radio-2"` for the Non paying radio. The appointments table inside the start visit form also renders radio buttons with `id="radio-0"` and `id="radio-1"`. When both are present in the DOM (appointments page launch only), the browser's `<label for="radio-1">` association resolves to the *first* element with that ID — the appointment row radio — so clicking the Paying label never selected the billing radio.

This did not occur when the start visit form was launched from the patient chart because the appointments table (and its `radio-0`/`radio-1` inputs) was not rendered alongside the billing form in that context.

**Fix:** Changed the radio IDs to `payment-details-paying` and `payment-details-non-paying`, which are unique and won't collide with any other IDs in the start visit form.

## Screenshots

**Before:** Clicking "Paying" does nothing — radio stays unselected.

https://github.com/user-attachments/assets/beb7dc21-5095-4ee2-8b20-446e22703638



**After:** Clicking "Paying" correctly selects the radio button.


https://github.com/user-attachments/assets/166d161c-8c5b-4771-a83f-753d9982784f



## Related Issue
https://issues.openmrs.org/browse/O3-5706

## Other