### PR TITLE
(fix) Pin swr to 2.2.5 to match the app shell and avoid share-scope skew

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react-i18next": "^16.0.0",
     "react-router-dom": "^6.21.3",
     "rxjs": "^6.6.7",
-    "swr": "^2.2.4",
+    "swr": "2.2.5",
     "turbo": "^2.5.2",
     "typescript": "^5.0.0",
     "vitest": "^4.0.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,7 +2141,7 @@ __metadata:
     react-router-dom: "npm:^6.21.3"
     react-to-print: "npm:^3.1.1"
     rxjs: "npm:^6.6.7"
-    swr: "npm:^2.2.4"
+    swr: "npm:2.2.5"
     turbo: "npm:^2.5.2"
     typescript: "npm:^5.0.0"
     vitest: "npm:^4.0.18"
@@ -13997,18 +13997,6 @@ __metadata:
   peerDependencies:
     react: ^16.11.0 || ^17.0.0 || ^18.0.0
   checksum: 10/f02b3bd5a198a0f62f9a53d7c0528c4a58aa61a43310bea169614b6e873dadb52599e856ef0775405b6aa7409835343da0cf328948aa892aa309bf4b7e7d6902
-  languageName: node
-  linkType: hard
-
-"swr@npm:^2.2.4":
-  version: 2.3.3
-  resolution: "swr@npm:2.3.3"
-  dependencies:
-    dequal: "npm:^2.0.3"
-    use-sync-external-store: "npm:^1.4.0"
-  peerDependencies:
-    react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/11cd5d1acbc62cf0e092e0d19f1d67b2e6ecb542602250f3277eb235750cd3285291bae9a8264c1f5b3973890f75234c104a0baf1ac6059aadc700ecba100fcc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including a conventional commit label.
- [ ] My work is based on designs
- [x] My work includes tests or is validated by existing tests. — existing unit/e2e suites.

## Summary

`swr` is shared as a Module Federation singleton across the O3 frontend. This app declared it as a caret range (`"^2.2.4"`), which resolves to `2.3.3`, while the app shell (`@openmrs/esm-app-shell`) and most apps (including `openmrs-esm-patient-chart`) pin `swr` exactly to `2.2.5`.

With two `swr` minor versions in the shared scope, singleton resolution binds consumers by container init order. `swr/immutable` and `swr/infinite` at 2.3.3 bind against the shell's eager `swr/_internal` at 2.2.5, so `SWRGlobalState.get(cache)` returns `undefined` and the patient chart crashes on render (`TypeError: undefined is not iterable`), intermittently failing distro e2e runs.

Pinning `swr` to `2.2.5` aligns this app with the app shell and removes its contribution to the skew. The same pin is needed in the other apps still shipping 2.3.3 (dispensing, stock-management, fast-data-entry, admin-tools).

## Screenshots

### Consistent undefined is not iterable error in Playwright trace

<img width="3406" height="1982" alt="CleanShot 2026-06-05 at 14 35 00@2x" src="https://github.com/user-attachments/assets/5f17a69b-e034-4459-9451-a49217dbe675" />

## Related Issue

## Other
