### PR TITLE
(test) Isolate BillingDashboard test to prevent unhandled swr error

### DIFF
--- a/src/billing-dashboard/billing-dashboard.test.tsx
+++ b/src/billing-dashboard/billing-dashboard.test.tsx
@@ -1,7 +1,20 @@
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { screen, render } from '@testing-library/react';
 import { BillingDashboard } from './billing-dashboard.component';
+
+vi.mock('../billing.resource', () => ({
+  usePaginatedBills: vi.fn(() => ({
+    bills: [],
+    error: null,
+    isLoading: false,
+    isValidating: false,
+    mutate: vi.fn(),
+    currentPage: 1,
+    totalCount: 0,
+    goTo: vi.fn(),
+  })),
+}));
 
 describe('BillingDashboard', () => {
   it('renders an empty state when there are no billing records', () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including a conventional commit label.
- [ ] My work is based on designs
- [x] My work includes tests or is validated by existing tests.

## Summary

The `BillingDashboard` test rendered `BillsTable` without mocking `../billing.resource`, so the real `usePaginatedBills` ran and reached the real `swr` package. That left a pending swr focus/visibility revalidation which rejected after the test file's jsdom environment was torn down, producing an intermittent unhandled rejection (`ReferenceError: document is not defined`, via swr's `isVisible`) that failed the whole `yarn test` run.

The sibling `bills-table.test.tsx` already mocks `../billing.resource`; this PR does the same for `billing-dashboard.test.tsx`, keeping the test isolated and deterministic. Verified with three consecutive clean runs (408 tests pass, 0 unhandled errors).

The flake surfaced after `swr` was pinned to `2.2.5` (#757); `swr` 2.3.3 had been masking it.

## Screenshots

## Related Issue

## Other
