### PR TITLE
(fix) O3-5733: Fix squished search bar height in invoice line items table

### DIFF
--- a/src/invoice/invoice-table.scss
+++ b/src/invoice/invoice-table.scss
@@ -34,6 +34,8 @@
 }
 
 .searchbox {
+  height: 3rem;
+
   input:focus {
     outline: 2px solid colors.$orange-40 !important;
   }
@@ -61,7 +63,7 @@
     border-bottom: 0.375rem solid var(--brand-03);
   }
 
-  & > span {
+  &>span {
     @include type.type-style('body-01');
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The search bar in the invoice line items table was rendering with insufficient height, appearing squished. Added an explicit `height: 3rem` to the `.searchbox` styles to match the expected Carbon design system sizing.

## Screenshots

**Before:**

The search bar appears very thin/squished.
<img width="1649" height="111" alt="Screenshot 2026-06-12 at 2 49 23 PM" src="https://github.com/user-attachments/assets/8fe5ebd5-0ea8-4a06-be13-9a9cdd7f2d82" />


**After:**

The search bar renders at the correct height with proper padding and icon alignment.
<img width="1649" height="136" alt="Screenshot 2026-06-12 at 2 48 15 PM" src="https://github.com/user-attachments/assets/cbbe4c4a-0072-4f36-ad12-44a60d89d27f" />


## Related Issue

https://issues.openmrs.org/browse/O3-5733

## Other

N/A