### PR TITLE
(fix) Keep patient chart siderail visible when launching the billing form

### DIFF
--- a/src/bill-history/bill-action-menu.component.tsx
+++ b/src/bill-history/bill-action-menu.component.tsx
@@ -35,7 +35,7 @@ const BillActionMenu: React.FC<BillActionMenuProps> = ({ bill, patientUuid, onMu
           className={styles.menuItem}
           itemText={t('addItemsToBill', 'Add items to bill')}
           onClick={() =>
-            launchWorkspace2('billing-form-workspace', {
+            launchWorkspace2('patient-chart-billing-form-workspace', {
               patientUuid,
               billUuid: bill.uuid,
               onMutate,

--- a/src/bill-history/bill-history.component.tsx
+++ b/src/bill-history/bill-history.component.tsx
@@ -114,7 +114,7 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
           <p className={styles.content}>{t('noBillsToDisplay', 'There are no bills to display.')}</p>
           <Button
             onClick={() =>
-              launchWorkspace2('billing-form-workspace', {
+              launchWorkspace2('patient-chart-billing-form-workspace', {
                 patientUuid,
                 onMutate: mutate,
               })
@@ -138,7 +138,7 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
         <Button
           kind="ghost"
           onClick={() =>
-            launchWorkspace2('billing-form-workspace', {
+            launchWorkspace2('patient-chart-billing-form-workspace', {
               patientUuid,
               onMutate: mutate,
             })

--- a/src/bill-history/bill-history.test.tsx
+++ b/src/bill-history/bill-history.test.tsx
@@ -192,7 +192,7 @@ describe('BillHistory', () => {
     const addItemsMenuItem = screen.getByText(/add items to bill/i);
     await user.click(addItemsMenuItem);
 
-    expect(mockLaunchWorkspace2).toHaveBeenCalledWith('billing-form-workspace', {
+    expect(mockLaunchWorkspace2).toHaveBeenCalledWith('patient-chart-billing-form-workspace', {
       patientUuid: 'some-uuid',
       billUuid: '1',
       onMutate: mockMutate,

--- a/src/routes.json
+++ b/src/routes.json
@@ -159,6 +159,11 @@
       "window": "billing-form-window"
     },
     {
+      "name": "patient-chart-billing-form-workspace",
+      "component": "billingFormWorkspace",
+      "window": "patient-chart-billing-form"
+    },
+    {
       "name": "billable-service-form",
       "component": "billableServiceFormWorkspace",
       "window": "billable-service-form-window"
@@ -168,6 +173,10 @@
     {
       "name": "billing-form-window",
       "group": "billingFormWorkspaceGroup"
+    },
+    {
+      "name": "patient-chart-billing-form",
+      "group": "patient-chart"
     },
     {
       "name": "billable-service-form-window",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

In the patient chart, launching the billing form via **Create bill** or **Add items to bill** made the chart's right-hand siderail (Clinical forms, Orders, Notes, Tasks, Patient lists) disappear.

The billing form was registered to its own workspace group (`billingFormWorkspaceGroup`). The workspaces2 system renders only one group's action menu at a time, so launching the form switched the active group away from `patient-chart` and dropped its siderail. Because the billing group defines no window icons of its own, nothing rendered in its place, so the rail vanished entirely.

This registers a chart-scoped workspace (`patient-chart-billing-form-workspace`) whose window belongs to the `patient-chart` group, and points the in-chart call sites (bill history and the bill action menu) at it. The form now opens as a window *within* the `patient-chart` group, so the group stays active and its siderail stays visible. The standalone billing pages (invoice, billable services) keep using the original `billing-form-workspace`.

## Screenshots

### Before 

https://github.com/user-attachments/assets/901767c2-3502-4444-9017-fc07dbeab49c

### After

https://github.com/user-attachments/assets/22b42b41-1efc-4961-926d-dcd8d6c8ae79

## Related Issue

## Other
