### PR TITLE
(fix) Keep the billing form quantity field empty when cleared

### DIFF
--- a/src/billing-form/billing-form.test.tsx
+++ b/src/billing-form/billing-form.test.tsx
@@ -196,6 +196,29 @@ describe('BillingForm', () => {
       const submitButton = screen.getByRole('button', { name: /save and close/i });
       expect(submitButton).toBeDisabled();
     });
+
+    it('keeps the quantity field empty when cleared instead of snapping back to "0"', async () => {
+      const user = userEvent.setup();
+      render(<BillingForm {...defaultCreateProps} />);
+
+      const combobox = screen.getByRole('combobox');
+      await user.click(combobox);
+      await user.click(screen.getByText('Consultation'));
+
+      const quantityInput = screen.getByRole('spinbutton');
+      expect(quantityInput).toHaveValue(1);
+
+      // Regression: clearing the field used to coerce the controlled value to 0, which both
+      // displayed a stuck "0" and produced a leading zero on the next keystroke. It should stay
+      // empty and surface the validation error instead.
+      await user.clear(quantityInput);
+      expect(quantityInput).toHaveValue(null);
+      expect(screen.getByText(/quantity must be at least 1/i)).toBeInTheDocument();
+
+      // Typing a new value replaces the empty field cleanly, with no leading zero.
+      await user.type(quantityInput, '5');
+      expect(quantityInput).toHaveValue(5);
+    });
   });
 
   describe('Edit mode (with billUuid)', () => {

--- a/src/billing-form/billing-form.workspace.tsx
+++ b/src/billing-form/billing-form.workspace.tsx
@@ -396,7 +396,7 @@ const BillingForm: React.FC<Workspace2DefinitionProps<BillingFormProps>> = ({
                           const number = parseFloat(String(value));
                           updateQuantity(item.uuid, isNaN(number) ? 0 : number);
                         }}
-                        value={item.quantity}
+                        value={item.quantity || ''}
                       />
                     </div>
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

The **Quantity** field in the "Add bill items" form can't be cleared: emptying it leaves a stuck `0`, and the next keystroke produces a leading zero (e.g. `05`). The `0` also trips the "Quantity must be at least 1" error.

The field is a controlled Carbon `NumberInput` with `allowEmpty`, but its `onChange` coerces an empty value to `0` and the displayed value is bound to that state, so a cleared field immediately re-renders as `0`. The fix renders `0` as empty (`value={item.quantity || ''}`).

This is a display-only change: the quantity stays a `number`, validation and totals are unchanged, and submission still requires `quantity >= 1`, so the cashier backend sees nothing different.

The other billing number inputs (edit bill item, selling price, payment amount, discount request) already handle the empty state correctly and weren't touched.

## Screenshots

### Before

https://github.com/user-attachments/assets/8313f5d9-3a06-49e5-8a6e-c213c561d2bc

### After

https://github.com/user-attachments/assets/fe3d5c3c-bb3f-46a4-922a-a87444ff5688

## Related Issue

## Other

Adds a regression test that clears the field and asserts it stays empty rather than `0`, surfaces the validation error, and accepts a new value without a leading zero.
