### PR TITLE
(chore) Fix the e2e Dockerfile

### DIFF
--- a/e2e/support/github/Dockerfile
+++ b/e2e/support/github/Dockerfile
@@ -24,10 +24,15 @@ RUN apk update && \
 RUN rm -rf /usr/share/nginx/html/*
 
 COPY --from=frontend /etc/nginx/nginx.conf /etc/nginx/nginx.conf
-# this assumes that NOTHING in the framework is in a subdirectory
-COPY --from=frontend /usr/share/nginx/html/* /usr/share/nginx/html/
+COPY --from=frontend /usr/share/nginx/html/ /usr/share/nginx/html/
 COPY --from=frontend /usr/local/bin/startup.sh /usr/local/bin/startup.sh
 RUN chmod +x /usr/local/bin/startup.sh
+
+# remove the nightly image's precompressed importmap and routes registry;
+# nginx serves .br/.gz variants first, and these would shadow the freshly
+# assembled plain files copied in below
+RUN rm -f /usr/share/nginx/html/importmap.json.br /usr/share/nginx/html/importmap.json.gz \
+  /usr/share/nginx/html/routes.registry.json.br /usr/share/nginx/html/routes.registry.json.gz
 
 COPY --from=dev /app/spa/ /usr/share/nginx/html/
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

Since openmrs/openmrs-distro-referenceapplication#1062, the nightly frontend image ships precompressed `importmap.json` and `routes.registry.json`, and its nginx config serves the `.br`/`.gz` variants before the plain files. The e2e image kept the stale compressed importmap from the nightly image, which points at versioned app directories that the glob `COPY` flattens, so e2e runs time out waiting for the shell to load. This broke e2e CI in several O3 repos starting 2026-08-21.

This copies the frontend files with their directory structure intact and removes the stale compressed variants, so the freshly assembled importmap and routes registry are the ones served. Same fix as openmrs/openmrs-esm-patient-management#2687.

## Screenshots

None.

## Related Issue

None.

## Other

None.
